### PR TITLE
NaN checks induced by values changes in a UITableView when swiping.

### DIFF
--- a/RangeSlider/RangeSlider.swift
+++ b/RangeSlider/RangeSlider.swift
@@ -190,11 +190,18 @@ class RangeSlider: UIControl {
         trackLayer.frame = bounds.insetBy(dx: 0.0, dy: bounds.height/3)
         trackLayer.setNeedsDisplay()
         
-        let lowerThumbCenter = CGFloat(positionForValue(lowerValue))
+        var lowerThumbCenter = CGFloat(positionForValue(lowerValue))
+        if lowerThumbCenter.isNaN.boolValue == true {
+            lowerThumbCenter = 0
+        }
+        
         lowerThumbLayer.frame = CGRect(x: lowerThumbCenter - thumbWidth/2.0, y: 0.0, width: thumbWidth, height: thumbWidth)
         lowerThumbLayer.setNeedsDisplay()
         
-        let upperThumbCenter = CGFloat(positionForValue(upperValue))
+        var upperThumbCenter = CGFloat(positionForValue(upperValue))
+        if upperThumbCenter.isNaN.boolValue == true {
+            upperThumbCenter = 0
+        }
         upperThumbLayer.frame = CGRect(x: upperThumbCenter - thumbWidth/2.0, y: 0.0, width: thumbWidth, height: thumbWidth)
         upperThumbLayer.setNeedsDisplay()
         


### PR DESCRIPTION
I have a few sliders that are dynamic in a UITableView, when updating, then subsequently swiping down the UITableView, the values returned from the method can produce a NaN. I added a check.